### PR TITLE
remove react router as we aren't actually rendering any routes.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,16 +1,13 @@
 require('./styles/main');
 import React from 'react';
 import { render } from 'react-dom';
-import { BrowserRouter, Match } from 'react-router';
 import App from './components/App';
 
 const Root = () => {
   return(
-    <BrowserRouter>
-      <section>
-        <Match exactly pattern='/' component={ App }/>
-      </section>
-    </BrowserRouter>
+    <main>
+      <App />
+    </main>
   )
 }
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "chai": "^3.5.0",
     "css-loader": "^0.26.1",
     "enzyme": "^2.7.0",
+    "file-loader": "^0.11.1",
     "firebase": "^3.6.4",
     "firebase-tools": "^3.2.1",
     "jsdom": "^9.9.1",
@@ -46,7 +47,6 @@
     "moment": "^2.17.1",
     "react": "^15.4.1",
     "react-addons-css-transition-group": "^15.4.1",
-    "react-dom": "^15.4.1",
-    "react-router": "^4.0.0-alpha.3"
+    "react-dom": "^15.4.1"
   }
 }


### PR DESCRIPTION
### Purpose
Remove React Router

### Approach
We had previously installed react-router 4 alpha, which has since gone through some changes.  anyone pulling the repo down was unable to build the project properly because it would install the new router and then cause errors.  

Since we never actually implemented any routing in this application, there was no need for react router.  I removed it.

I also added the file-loader package as it was a peer dependency of url-loader. 